### PR TITLE
Update FacebookClientManager.android.cs

### DIFF
--- a/src/Plugin.FacebookClient/FacebookClientManager.android.cs
+++ b/src/Plugin.FacebookClient/FacebookClientManager.android.cs
@@ -583,7 +583,10 @@ namespace Plugin.FacebookClient
             else
             {
                 var fbResponse = new FBEventArgs<string>(null, FacebookActionStatus.Canceled, "User cancelled facebook operation");
-                _onUserData.Invoke(CrossFacebookClient.Current, fbResponse);
+                if(_onUserData != null)
+                {
+                    _onUserData.Invoke(CrossFacebookClient.Current, fbResponse);
+                }
                 _userDataTcs?.TrySetResult(new FacebookResponse<string>(fbResponse));
             }
 


### PR DESCRIPTION
If the user never subscribes to the event "OnUserData", then we should not try to invoke it. Invoking this null event, will crash the app. Simply check to see if its null, first.

Please take a moment to fill out the following:

Fixes # . 63 and 84
